### PR TITLE
Fix issue where setting attributedText could override properties

### DIFF
--- a/Nantes/Nantes.xcodeproj/project.pbxproj
+++ b/Nantes/Nantes.xcodeproj/project.pbxproj
@@ -211,7 +211,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "swift run swiftlint --path .. --strict --quiet\n";
+			shellScript = "if [ -z \"$CARTHAGE\" ]\nthen\n    swift run swiftlint --path .. --strict --quiet\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Nantes/Nantes.xcodeproj/xcshareddata/xcschemes/Nantes.xcscheme
+++ b/Nantes/Nantes.xcodeproj/xcshareddata/xcschemes/Nantes.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference

--- a/Source/Classes/NantesLabel.swift
+++ b/Source/Classes/NantesLabel.swift
@@ -309,18 +309,11 @@ public extension NSAttributedString.Key {
         get {
             return _attributedText
         } set {
-            let attributes = NSAttributedString.attributes(from: self)
-            guard let updatedText = newValue?.mutableCopy() as? NSMutableAttributedString else {
+            guard newValue != _attributedText else {
                 return
             }
 
-            updatedText.addAttributes(attributes, range: NSRange(location: 0, length: updatedText.length))
-
-            guard updatedText != _attributedText else {
-                return
-            }
-
-            _attributedText = updatedText
+            _attributedText = newValue
             setNeedsFramesetter()
             _accessibilityElements = nil
             linkModels = []
@@ -541,6 +534,17 @@ public extension NSAttributedString.Key {
     }
 
     // MARK: - Public
+
+    public func setAttributedText(_ attributedString: NSAttributedString, afterInheritingLabelAttributesAndConfiguringWithBlock block: ((NSMutableAttributedString) -> NSMutableAttributedString)?) {
+        var mutableAttributedString = NSMutableAttributedString(attributedString: attributedString)
+        mutableAttributedString.addAttributes(NSAttributedString.attributes(from: self), range: NSRange(location: 0, length: attributedString.length))
+
+        if let block = block {
+            mutableAttributedString = block(mutableAttributedString)
+        }
+
+        attributedText = mutableAttributedString
+    }
 
     /// Adds a single link
     open func addLink(_ link: NantesLabel.Link) {

--- a/Source/Classes/NantesLabel.swift
+++ b/Source/Classes/NantesLabel.swift
@@ -535,6 +535,13 @@ public extension NSAttributedString.Key {
 
     // MARK: - Public
 
+    /// Use this setter when you want to set attributes on NantesLabel before setting attributedText and have the properties get copied over
+    /// This will overwrite properties set on the attributedString passed in, if they're set on NantesLabel. Use `attributedText` if you want
+    /// to keep the properties inside attributedString
+    ///
+    /// More info:
+    /// Check out the `testAttributedStringPropertiesUpdate` test and `testAttributedStringPropertiesUpdateWithBlock` and compare them against
+    /// `testAttributedStringPropertiesStay` for expected behavior against the functions
     public func setAttributedText(_ attributedString: NSAttributedString, afterInheritingLabelAttributesAndConfiguringWithBlock block: ((NSMutableAttributedString) -> NSMutableAttributedString)?) {
         var mutableAttributedString = NSMutableAttributedString(attributedString: attributedString)
         mutableAttributedString.addAttributes(NSAttributedString.attributes(from: self), range: NSRange(location: 0, length: attributedString.length))


### PR DESCRIPTION
There was a regression in 0.0.5 that caused properties that were set on
the label to overwrite the properties of the attributedString the user
was setting on attributedText. This fixes that regression by reverting
the changes that were made to the didSet block of attributedText. Since
there's a valid use-case for wanting to set properties on the label
and have them overwrite the properties inside the attributedstring, I've
added another function `setAttributedText(_ attributedString:
NSAttributedString,
afterInheritingLabelAttributesAndConfiguringWithBlock block:
((NSMutableAttributedString) -> NSMutableAttributedString)?)` to support
that.