### PR TITLE
Stop touches being passed to other views if we handle them

### DIFF
--- a/Source/Classes/NantesLabel.swift
+++ b/Source/Classes/NantesLabel.swift
@@ -491,7 +491,9 @@ public extension NSAttributedString.Key {
     override open func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         guard let touch = touches.first,
             let activeLink = link(at: touch.location(in: self)) else {
-                super.touchesBegan(touches, with: event)
+                if labelTappedBlock == nil {
+                    super.touchesBegan(touches, with: event)
+                }
                 return
         }
 


### PR DESCRIPTION
We've been encountering issues where tapping on the label still forwards those taps up the view hierarchy, which if you are using the label in a UITableViewCell causes the cell to be selected.

This fix ensures that if the label handles the tap (because its `labelTappedBlock` is set) we don't forward the taps on