### PR TITLE
[WIP] Add base attributes from whats set on the label when setting attributed text

### DIFF
--- a/Source/Classes/NantesLabel.swift
+++ b/Source/Classes/NantesLabel.swift
@@ -309,11 +309,22 @@ public extension NSAttributedString.Key {
         get {
             return _attributedText
         } set {
-            guard newValue != _attributedText else {
+            guard let newValue = newValue else {
+                _attributedText = nil
                 return
             }
 
-            _attributedText = newValue
+            let attributes = NSAttributedString.attributes(from: self)
+            let final = NSMutableAttributedString(string: newValue.string, attributes: attributes)
+            newValue.enumerateAttributes(in: NSRange(location: 0, length: newValue.length), options: []) { attributes, range, _ in
+                final.addAttributes(attributes, range: range)
+            }
+
+            guard final != _attributedText else {
+                return
+            }
+
+            _attributedText = final
             setNeedsFramesetter()
             _accessibilityElements = nil
             linkModels = []


### PR DESCRIPTION
When setting attributed text on nantes, we don't take into account any settings that are already set on the label. So if you set something like kern, and then set attributed text without overwriting kern inside the attributed text, we don't use the kern value you set originally on the label. 

Since this is a breaking change, this will go in a newer version.