### PR TITLE
Pass a `linkTappedBlock` handler when adding multiple links to a single label

### DIFF
--- a/Source/Classes/ActionHandling/Link.swift
+++ b/Source/Classes/ActionHandling/Link.swift
@@ -47,7 +47,7 @@ extension NantesLabel {
     /// Adds a link to a `url` with a specified `range`
     @discardableResult
     open func addLink(to url: URL, withRange range: NSRange, linkTappedBlock: NantesLabel.LinkTappedBlock? = nil) -> NantesLabel.Link? {
-		return addLinks(with: [.linkCheckingResult(range: range, url: url)], withAttributes: linkAttributes, linkTappedBlock: linkTappedBlock).first
+        return addLinks(with: [.linkCheckingResult(range: range, url: url)], withAttributes: linkAttributes, linkTappedBlock: linkTappedBlock).first
     }
 
     @discardableResult

--- a/Source/Classes/ActionHandling/Link.swift
+++ b/Source/Classes/ActionHandling/Link.swift
@@ -46,12 +46,12 @@ extension NantesLabel {
 
     /// Adds a link to a `url` with a specified `range`
     @discardableResult
-    open func addLink(to url: URL, withRange range: NSRange) -> NantesLabel.Link? {
-        return addLinks(with: [.linkCheckingResult(range: range, url: url)], withAttributes: linkAttributes).first
+    open func addLink(to url: URL, withRange range: NSRange, linkTappedBlock: NantesLabel.LinkTappedBlock? = nil) -> NantesLabel.Link? {
+		return addLinks(with: [.linkCheckingResult(range: range, url: url)], withAttributes: linkAttributes, linkTappedBlock: linkTappedBlock).first
     }
 
     @discardableResult
-    private func addLinks(with textCheckingResults: [NSTextCheckingResult], withAttributes attributes: [NSAttributedString.Key: Any]?) -> [NantesLabel.Link] {
+    private func addLinks(with textCheckingResults: [NSTextCheckingResult], withAttributes attributes: [NSAttributedString.Key: Any]?, linkTappedBlock: NantesLabel.LinkTappedBlock? = nil) -> [NantesLabel.Link] {
         var links: [NantesLabel.Link] = []
 
         for result in textCheckingResults {
@@ -61,7 +61,7 @@ extension NantesLabel {
                 text = String(checkingText[range])
             }
 
-            let link = NantesLabel.Link(attributes: attributes, activeAttributes: activeLinkAttributes, inactiveAttributes: inactiveLinkAttributes, linkTappedBlock: nil, result: result, text: text)
+            let link = NantesLabel.Link(attributes: attributes, activeAttributes: activeLinkAttributes, inactiveAttributes: inactiveLinkAttributes, linkTappedBlock: linkTappedBlock, result: result, text: text)
             links.append(link)
         }
 


### PR DESCRIPTION
This is necessary because the `linkTappedBlock` can't be set after a link got created using `addLink(to:URL)` method since the Link DTO is a struct.

It may sound pointless because we already have to pass an URL which then calls a delegate method when being tapped but we have a case where we add multiple links to a single label and each link press is handled differently.