### PR TITLE
SPM package for Swift 5.3

### DIFF
--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "Nantes",
+    platforms: [.iOS(.v9)],
+    products: [
+        .library(name: "Nantes", targets: ["Nantes"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "Nantes",
+            path: "Source/Classes",
+            exclude: ["Nantes.h"]
+        )
+    ]
+)


### PR DESCRIPTION
Adding Swift 5.3 specific SPM package without breaking compatibility for iOS 8. 

Fixes Xcode 12 warning mentioned here 👉  #64 