### PR TITLE
Use custom concurrent queue instead of DispatchQueue.global()

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Source/Classes/ActionHandling/Link.swift
+++ b/Source/Classes/ActionHandling/Link.swift
@@ -176,7 +176,7 @@ extension NantesLabel {
                 return
         }
 
-        DispatchQueue.global(qos: .default).async { [weak self] in
+        self.nantesQueue.async { [weak self] in
             guard let self = self else {
                 return
             }

--- a/Source/Classes/NantesLabel.swift
+++ b/Source/Classes/NantesLabel.swift
@@ -113,6 +113,12 @@ import UIKit
 
     private var _renderedAttributedText: NSAttributedString?
 
+    // MARK: - Internal lets
+    
+    let nantesQueue = DispatchQueue(label: "com.Nantes.NantesQueue",
+                                            qos: .userInitiated,
+                                            attributes: .concurrent)
+    
     // MARK: - Internal vars
 
     var _accessibilityElements: [Any]?


### PR DESCRIPTION
"Global queues easily lead to thread explosion and" and "Global queues also do not play nice with qos/priorities" :

https://gist.github.com/tclementdev/6af616354912b0347cdf6db159c37057