### PR TITLE
Fixed a deprecation warning where some protocols were inheriting from  class instead of AnyObject per Xcode's suggestion

### DIFF
--- a/Source/Classes/Delegate/LabelDelegate.swift
+++ b/Source/Classes/Delegate/LabelDelegate.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public protocol NantesLabelDelegate: class {
+public protocol NantesLabelDelegate: AnyObject {
     func attributedLabel(_ label: NantesLabel, didSelectAddress addressComponents: [NSTextCheckingKey: String])
     func attributedLabel(_ label: NantesLabel, didSelectDate date: Date, timeZone: TimeZone, duration: TimeInterval)
     func attributedLabel(_ label: NantesLabel, didSelectLink link: URL)


### PR DESCRIPTION
I was updating my iOS app to be able to run on Xcode 12.5 (beta) and noticed that Apple is now flagging the use of class inherited protocols as deprecated in favor of inheriting from AnyObject. In my iOS app, we flag warnings as errors so now our app won't compile. I wanted to be able to pitch in and help modernize the code so I went ahead and fixed this deprecation here.

<img width="1122" alt="Screen Shot 2021-04-09 at 12 51 52 PM" src="https://user-images.githubusercontent.com/1315688/114233892-dc65b680-9932-11eb-9516-48dd79382b18.png">

After a little bit of research, I came across this forum Swift.org [post](https://forums.swift.org/t/class-only-protocols-class-vs-anyobject/11507/4) which seems to point to the discussion where this deprecation discussion started.