### PR TITLE
Backward compatible support

### DIFF
--- a/Source/Classes/Drawing/Drawing.swift
+++ b/Source/Classes/Drawing/Drawing.swift
@@ -113,8 +113,16 @@ extension NantesLabel {
             let lineOrigin = lineOrigins[lineIndex]
             context.textPosition = lineOrigin
             let line = lines[lineIndex]
+
+            var yOffset = lineOrigin.y
+
+            if isLegacyDrawAttributedString {
+                var descent: CGFloat = 0.0
+                CTLineGetTypographicBounds(line, nil, &descent, nil)
+                yOffset = lineOrigin.y - descent - font.descender
+            }
+
             let penOffset = CGFloat(CTLineGetPenOffsetForFlush(line, flushFactor, Double(rect.size.width)))
-            let yOffset = lineOrigin.y
             context.textPosition = CGPoint(x: penOffset, y: yOffset)
             CTLineDraw(line, context)
         }

--- a/Source/Classes/Drawing/Drawing.swift
+++ b/Source/Classes/Drawing/Drawing.swift
@@ -116,7 +116,7 @@ extension NantesLabel {
 
             var yOffset = lineOrigin.y
 
-            if isLegacyDrawAttributedString {
+            if usesLegacyVerticalAlignment {
                 var descent: CGFloat = 0.0
                 CTLineGetTypographicBounds(line, nil, &descent, nil)
                 yOffset = lineOrigin.y - descent - font.descender

--- a/Source/Classes/NantesLabel.swift
+++ b/Source/Classes/NantesLabel.swift
@@ -98,6 +98,10 @@ import UIKit
     /// Vertical alignment of the text within its frame
     /// defaults to .center
     open var verticalAlignment: NantesLabel.VerticalAlignment = .center
+    
+    /// The flag for drawing text in legacy way that single line of text isn't perfect vertical centered.
+    /// This flag gives control to client for opt-out new changes that an existing UI could build on top of older version.
+    var isLegacyDrawAttributedString: Bool = false
 
     // MARK: - Private vars
 

--- a/Source/Classes/NantesLabel.swift
+++ b/Source/Classes/NantesLabel.swift
@@ -101,7 +101,7 @@ import UIKit
     
     /// The flag for drawing text in legacy way that single line of text isn't perfect vertical centered.
     /// This flag gives control to client for opt-out new changes that an existing UI could build on top of older version.
-    open var isLegacyDrawAttributedString: Bool = false
+    open var usesLegacyVerticalAlignment: Bool = false
 
     // MARK: - Private vars
 

--- a/Source/Classes/NantesLabel.swift
+++ b/Source/Classes/NantesLabel.swift
@@ -101,7 +101,7 @@ import UIKit
     
     /// The flag for drawing text in legacy way that single line of text isn't perfect vertical centered.
     /// This flag gives control to client for opt-out new changes that an existing UI could build on top of older version.
-    var isLegacyDrawAttributedString: Bool = false
+    open var isLegacyDrawAttributedString: Bool = false
 
     // MARK: - Private vars
 


### PR DESCRIPTION
The last PR https://github.com/instacart/Nantes/pull/87 fixed single line of text not vertical centered. 
But it's possible that an existing UI is built on top of older version. Giving control to clients to opt-out new changes.